### PR TITLE
FEAT: 홈 화면 날씨 문구별 아이콘 매핑 기능 구현

### DIFF
--- a/weather-assistant/package-lock.json
+++ b/weather-assistant/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "chart.js": "^4.4.9",
+        "lucide-react": "^0.513.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
@@ -11235,6 +11236,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
+      "integrity": "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/weather-assistant/package.json
+++ b/weather-assistant/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "chart.js": "^4.4.9",
+    "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",

--- a/weather-assistant/src/App.js
+++ b/weather-assistant/src/App.js
@@ -3,7 +3,7 @@ import './App.css';
 import Home from './screens/Home/Home';
 import Chat from './screens/Chat/Chat';
 import VoiceInput from './screens/VoiceInput/VoiceInput';
-// import { geminiApi } from './services/geminiApi';
+
 
 function App() {
   const [view, setView] = useState('home');

--- a/weather-assistant/src/screens/Home/Home.css
+++ b/weather-assistant/src/screens/Home/Home.css
@@ -186,6 +186,7 @@
 
   width: auto; /* 텍스트 길이에 따라 자동 조정 */
   height: 22px;
+  white-space: nowrap;  /* 줄바꿈 방지 */
   
   position: absolute;
   top: 242px;                    /* 상태바(59) + 헤더(56) + 날짜(38) = 153px */
@@ -689,4 +690,30 @@
 .send-button:disabled:hover {
   transform: none;
   background: linear-gradient(45deg, #97F5FD 15.63%, #EEB4F3 85.42%);
+}
+
+
+/* 날씨 description 컨테이너 - 아이콘과 텍스트를 가로로 배치 */
+.weather-description-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px; /* 아이콘과 텍스트 사이 간격 */
+}
+
+/* 날씨 아이콘 스타일 */
+.weather-icon {
+  width: 16px !important;
+  height: 16px !important;
+  color: #FFFFFF;
+  flex-shrink: 0; /* 아이콘 크기 고정 */
+}
+
+/* 날씨 텍스트 스타일 */
+.weather-text {
+  font-family: 'Poppins', sans-serif;
+  font-size: 16px;
+  font-weight: 300;
+  color: #FFFFFF;
+  line-height: 22px;
 }

--- a/weather-assistant/src/screens/Home/Home.css
+++ b/weather-assistant/src/screens/Home/Home.css
@@ -182,7 +182,7 @@
 
 
 /* 기상 정보 */
-.condition {
+.description {
 
   width: auto; /* 텍스트 길이에 따라 자동 조정 */
   height: 22px;

--- a/weather-assistant/src/screens/Home/Home.js
+++ b/weather-assistant/src/screens/Home/Home.js
@@ -14,6 +14,15 @@ const Home = ({
   const today = new Date();
   const formattedDate = formatDate(today); // ex. "May 24, Monday"
 
+    //  날씨 테스트 코드 
+  console.log('=== 날씨 테스트 ===');
+  console.log('weather 객체:', weather);
+  console.log('weatherId:', weather?.weatherId);
+  console.log('description:', weather?.description);
+  console.log('condition:', weather?.condition);
+  console.log('==================');
+
+
   return (
     <div className="app-container"> {/* ✅ 공통 정렬용 래퍼 추가 */}
       {/* 헤더 - 모든 버튼을 일관성 있게 */}
@@ -62,15 +71,17 @@ const Home = ({
           
 
         {/* 기상 정보 */}
-        <p className="condition">{weather
-          ? `${weather.condition}` : 'Loading...' } </p>
-
-        {/* 체감온도/최고/최저 */}
-        <p className="sub-summary">
-          {weather ? 
-          `Feels like ${weather.feelsLike}° | H: ${weather.tempMax}° L: ${weather.tempMin}°` 
-          : 'Loading...'}
+        <p className="description">
+          {weather?.description ? 
+            weather.description.charAt(0).toUpperCase() + weather.description.slice(1).toLowerCase()
+            : 'Loading...'}
         </p>
+                  {/* 체감온도/최고/최저 */}
+          <p className="sub-summary">
+            {weather ? 
+            `Feels like ${weather.feelsLike}° | H: ${weather.tempMax}° L: ${weather.tempMin}°` 
+            : 'Loading...'}
+           </p>
       </div>
 
       <div className="background-media">

--- a/weather-assistant/src/screens/Home/Home.js
+++ b/weather-assistant/src/screens/Home/Home.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Home.css';
+import { WeatherDescriptionWithIcon } from './weatherIconUtils';
 
 const Home = ({ 
   time, 
@@ -14,13 +15,6 @@ const Home = ({
   const today = new Date();
   const formattedDate = formatDate(today); // ex. "May 24, Monday"
 
-    //  날씨 테스트 코드 
-  console.log('=== 날씨 테스트 ===');
-  console.log('weather 객체:', weather);
-  console.log('weatherId:', weather?.weatherId);
-  console.log('description:', weather?.description);
-  console.log('condition:', weather?.condition);
-  console.log('==================');
 
 
   return (
@@ -69,19 +63,17 @@ const Home = ({
           ? `${weather.temp}°` : `00°C` } </p>
                     {/* ? `${weather.temp}°C` : `00°C` } </p> */}
           
-
         {/* 기상 정보 */}
         <p className="description">
-          {weather?.description ? 
-            weather.description.charAt(0).toUpperCase() + weather.description.slice(1).toLowerCase()
-            : 'Loading...'}
+          <WeatherDescriptionWithIcon weather={weather} />
         </p>
-                  {/* 체감온도/최고/최저 */}
-          <p className="sub-summary">
-            {weather ? 
-            `Feels like ${weather.feelsLike}° | H: ${weather.tempMax}° L: ${weather.tempMin}°` 
-            : 'Loading...'}
-           </p>
+
+        {/* 체감온도/최고/최저 */}
+        <p className="sub-summary">
+          {weather ? 
+          `Feels like ${weather.feelsLike}° | H: ${weather.tempMax}° L: ${weather.tempMin}°` 
+          : 'Loading...'}
+        </p>
       </div>
 
       <div className="background-media">

--- a/weather-assistant/src/screens/Home/weatherIconUtils.js
+++ b/weather-assistant/src/screens/Home/weatherIconUtils.js
@@ -1,0 +1,143 @@
+// 아이콘 매핑 기준: https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
+import { 
+  // 맑은 날씨
+  Sun,               // 맑음 (낮)
+  MoonStar,          // 맑음 (밤)
+  
+  // 구름
+  Cloud,             // 구름 (중간량)
+  CloudSun,          // 구름 적음 (낮)
+  CloudMoon,         // 구름 적음 (밤)
+  Cloudy,            // 구름 많음
+  
+  // 강수 현상
+  CloudSunRain,      // 비 (낮)
+  CloudMoonRain,     // 비 (밤)
+  CloudDrizzle,      // 이슬비
+  Snowflake,         // 눈
+  
+  // 극한 날씨
+  Zap,               // 뇌우
+  Tornado,           // 토네이도
+  
+  // 대기 현상
+  CloudFog,          // 안개
+  Haze,              // 연무
+  Wind,              // 돌풍/먼지/모래
+  AlertTriangle      // 화산재 경고
+} from 'lucide-react';
+
+// OpenWeatherMap의 weatherId를 기반으로 한 아이콘 매핑
+export const getWeatherIcon = (weatherId, timestamp = null) => {
+  // 밤/낮 판단 (timestamp가 있으면 사용, 없으면 현재 시간 사용)
+  const checkTime = timestamp ? new Date(timestamp) : new Date();
+  const hour = checkTime.getHours();
+  const isNight = hour < 6 || hour > 18;
+  
+  // 날씨 ID 범위별 아이콘 매핑
+  if (weatherId >= 200 && weatherId < 300) {
+    // 뇌우 (Thunderstorm)
+    return Zap;
+
+  } else if (weatherId >= 300 && weatherId < 400) {
+    // 이슬비 (Drizzle)
+
+    return CloudDrizzle;
+
+  } else if (weatherId >= 500 && weatherId < 600) {
+    // 비 (Rain) - 특별한 케이스 먼저 처리
+    if (weatherId === 511) {
+      // Freezing rain (어는 비)
+      return Snowflake;
+    } else if (isNight) {
+      return CloudMoonRain; // 일반 비 (밤)
+    } else {
+      return CloudSunRain;  // 일반 비 (낮)
+    }
+ 
+  } else if (weatherId >= 600 && weatherId < 700) {
+    // 눈 (Snow)
+    return Snowflake;
+
+  } else if (weatherId >= 700 && weatherId < 800) {
+    // 대기 현상 (Atmosphere) - 각각 어울리는 아이콘으로 매핑
+    switch (weatherId) {
+      case 701: // Mist (안개) - mist
+        return CloudFog;
+
+      case 711: // Smoke (연기) - smoke
+        return CloudFog;
+        
+      case 721: // Haze (연무) - haze
+        return Haze;
+
+      case 731: // Dust (먼지) - sand/dust whirls
+        return Wind;
+
+      case 741: // Fog (안개) - fog
+        return CloudFog;
+
+      case 751: // Sand (모래) - sand
+        return Wind;
+
+      case 761: // Dust (먼지) - dust
+        return Wind;
+
+      case 762: // Ash (화산재) - volcanic ash
+        return AlertTriangle;
+
+      case 771: // Squalls (돌풍) - squalls
+        return Wind;
+
+      case 781: // Tornado (토네이도) - tornado
+        return Tornado;
+
+      default:
+        return Wind;
+    }
+  } else if (weatherId === 800) {
+    // 맑음 (Clear sky)
+    return isNight ? MoonStar : Sun;
+
+  } else if (weatherId > 800) {
+    // 구름 (Clouds) - 구름량과 밤/낮에 따라 세분화
+
+    if (weatherId === 801) {
+      // Few clouds (11-25%) - 해/달과 함께 있는 약간의 구름
+      return isNight ? CloudMoon : CloudSun;
+
+    } else if (weatherId === 802) {
+      // Scattered clouds (25-50%) - 일반 구름
+
+      return Cloud;
+    } else {
+      // Broken/Overcast clouds (51-100%) - 많은 구름
+      return Cloudy;
+    }
+  }
+  // 기본값
+  return Cloud;
+};
+
+// 아이콘 컴포넌트 (description과 함께 렌더링)
+export const WeatherDescriptionWithIcon = ({ weather, className = "" }) => {
+  if (!weather) {
+    return <p className={className}>Loading...</p>;
+  }
+
+  const IconComponent = getWeatherIcon(weather.weatherId, weather.timestamp);
+  const description = weather.description 
+    ? weather.description.charAt(0).toUpperCase() + weather.description.slice(1).toLowerCase()
+    : 'Loading...';
+
+  return (
+    <div className={`weather-description-container ${className}`}>
+      <IconComponent 
+        size={20} 
+        className="weather-icon"
+        color="#FFFFFF"
+      />
+      <span className="weather-text">{description}</span>
+    </div>
+  );
+};


### PR DESCRIPTION
# 요약
홈 화면 UI에서 날씨 문구에 따라 아이콘이 자동으로 매핑되도록 구현하였습니다.

# 작업내용
- OpenWeatherMap의 weatherId를 기반으로 날씨 상태별 아이콘을 매핑하였습니다.
- description과 함께 아이콘이 출력되도록 구성했습니다.
- lucide-react 라이브러리를 활용해 아이콘이 자동으로 렌더링되도록 구현했습니다.
- 아이콘 매핑 로직을 Home/weatherIconUtils.js로 분리하여 모듈화하였습니다. 
- 날씨 상태와 밤/낮에 따라 다른 아이콘이 표시되도록 처리했습니다. (아이콘 매핑 기준: https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2)

# 참고사항
- 프론트엔드 /weather-assistant 경로에서 다음 패키지 설치가 필요합니다: `npm install lucide-react`
