### PR TITLE
FEAT: 미세먼지 수치 시각화 그래프 기능 구현

### DIFF
--- a/weather-assistant/src/App.js
+++ b/weather-assistant/src/App.js
@@ -90,6 +90,44 @@ const handleBackToHome = () => {
       const graphCoords = data.resolvedCoords || coords;
       console.log('📍 resolvedCoords:', graphCoords);
 
+      // 미세먼지 정보가 포함되어 있으면 추가 메시지 구성
+      if (data.airQuality && data.airQuality.pm25 !== undefined) {
+        const { pm25 } = data.airQuality;
+
+        const getAirLevel = (value) => {
+          if (value <= 15) return '좋음';
+          if (value <= 35) return '보통';
+          if (value <= 75) return '나쁨';
+          return '매우 나쁨';
+        };
+
+        const getAirColor = (value) => {
+          if (value <= 15) return '#22c55e';   // green
+          if (value <= 35) return '#facc15';   // yellow
+          if (value <= 75) return '#f97316';   // orange
+          return '#ef4444';                    // red
+        };
+
+        const dustInfo = {
+          value: pm25,
+          level: getAirLevel(pm25),
+          color: getAirColor(pm25)
+        };
+
+        // '생각 중...' 메시지 제거 후 응답 메시지 + dust 정보 반영
+        setMessages(prev => {
+          const newMessages = [...prev];
+          newMessages.pop(); // 로딩 제거
+          return [...newMessages, {
+            type: 'bot',
+            text: data.reply,
+            dust: dustInfo
+          }];
+        });
+
+        return; // 미세먼지 응답이면 여기서 종료
+      }
+
       // 기온 질문 시 그래프 요청
       let graphData = null;
       if (

--- a/weather-assistant/src/screens/Chat/Chat.js
+++ b/weather-assistant/src/screens/Chat/Chat.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Chat.css';
-import WeatherLineChart from './WeatherLineChart'; // 경로는 파일 위치에 따라 조절
+import WeatherLineChart from './WeatherLineChart';
+import DustLevelChart from './DustLevelChart';
 
 const Chat = ({ 
   messages, 
@@ -145,6 +146,11 @@ const Chat = ({
                       ) : (
                         // 일반 메시지
                         m.text
+                      )}
+                      
+                      {/* 👇 미세먼지 시각화 그래프 삽입 */}
+                      {m.dust && typeof m.dust.value === 'number' && (
+                        <DustLevelChart value={m.dust.value} />
                       )}
                     </div>
                   )}

--- a/weather-assistant/src/screens/Chat/DustLevelChart.css
+++ b/weather-assistant/src/screens/Chat/DustLevelChart.css
@@ -1,0 +1,118 @@
+.dust-air-box {
+    background: linear-gradient(135deg, #2d3748 0%, #4a5568 100%);
+    border-radius: 20px;
+    padding: 18px 18px 17px 18px;
+    color: white;
+    width: 100%;
+    max-width: 320px;
+    margin-top: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.dust-air-header {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 12px;
+}
+
+.title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.title {
+    font-size: 15px;
+    font-weight: 500;
+    color: #ffffff;
+    margin-bottom: 6px;
+    line-height: 1.2;
+}
+
+.value-large {
+    font-size: 25px;
+    font-weight: 700;
+    color: #f97316;
+    line-height: 1;
+    text-align: right;
+}
+
+.subtitle-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0px;
+}
+
+.subtitle-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.subtitle {
+    font-size: 12px;
+    color: #e2e8f0;
+    font-weight: 400;
+    margin: 0;
+}
+
+.badge {
+    padding: 2px 6px;
+    border-radius: 20px;
+    font-size: 8px;
+    font-weight: 600;
+    text-transform: capitalize;
+    letter-spacing: 0.5px;
+}
+
+.unit-text {
+    font-size: 9px;
+    color: #94a3b8;
+    font-weight: 400;
+    text-align: center;
+}
+
+.dust-graph-container {
+    margin-top: 10px;
+    margin-bottom: 8px;
+    position: relative;
+    width: 100%;
+    height: 18px;
+    background: linear-gradient(90deg, 
+        #7ED6A8 0%,
+        #FFE57F 19%,
+        #FFA059 44%,
+        #F36C6C 100%
+    );
+    border-radius: 12px;
+    overflow: visible;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.circle-indicator {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background-color: #c9c9c9;
+    border: 2px solid #ffffff;
+    z-index: 10;
+}
+
+.dust-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    color: #ffffff;
+    padding: 0 4px;
+}
+
+.dust-labels span {
+    font-weight: 500;
+    letter-spacing: 0.3px;
+}

--- a/weather-assistant/src/screens/Chat/DustLevelChart.js
+++ b/weather-assistant/src/screens/Chat/DustLevelChart.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import './DustLevelChart.css';
+
+const getLevelLabel = (value) => {
+  if (value <= 15) return 'Good';
+  if (value <= 35) return 'Moderate';
+  if (value <= 75) return 'Poor';
+  return 'Very Poor';
+};
+
+const getBadgeColor = (value) => {
+  // 바의 그라데이션에 따른 색상 계산
+  if (value <= 15) return '#7ED6A8'; // Good - 녹색
+  if (value <= 35) return '#FFE57F'; // Moderate - 노란색
+  if (value <= 75) return '#FFA059'; // Poor - 주황색
+  return '#F36C6C'; // Very Poor - 빨간색
+};
+
+const DustLevelChart = ({ value }) => {
+  const level = getLevelLabel(value);
+  const badgeColor = getBadgeColor(value);
+  const position = Math.min((value / 100) * 100, 100); // 최대 100 기준
+
+  return (
+    <div className="dust-air-box">
+      <div className="dust-air-header">
+        <div className="title-row">
+          <div className="title-left">
+            <p className="title">Tomorrow's Air Quality</p>
+            <div className="subtitle-left">
+              <p className="subtitle">PM2.5 Standard</p>
+              <span 
+                className="badge" 
+                style={{ backgroundColor: badgeColor, color: 'black' }}
+              >
+                {level}
+              </span>
+            </div>
+          </div>
+          <div className="title-right">
+            <p className="value-large" style={{ color: badgeColor}}>
+                {Math.ceil(value)}
+            </p>
+            <p className="unit-text">µg/m³</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="dust-graph-container">
+        <div className="circle-indicator" style={{ left: `${position}%` }} />
+      </div>
+
+      <div className="dust-labels">
+        <p>Good</p>
+        <p>Moderate</p>
+        <p>Poor</p>
+        <p>Very Poor</p>
+      </div>
+    </div>
+  );
+};
+
+export default DustLevelChart;


### PR DESCRIPTION
# 요약
미세먼지 수치 시각화 그래프 기능 구현

# 작업내용
![image](https://github.com/user-attachments/assets/940927a0-b78b-4277-8f03-ce1e682e23fb)  ![image](https://github.com/user-attachments/assets/6be046d8-4044-4904-8dfb-96fbf22ac56d)

1. 백엔드에서 받은 수치를 기반으로 막대(최대 100이라고 가정)와 원을 겹쳐 시각화 - 프론트에 `DustLevelChart.js` 추가
2. 받은 입력에 미세먼지 관련 정보가 포함되어 있으면 그래프를 출력하도록 (App.js, Chat.js)
3. `DustLevelChart.css` 추가

# 참고사항
- pm2.5 기준입니다.
- 백엔드 부분은 다음 PR 링크를 확인해주세요. https://github.com/havetodo-yeon/weather-assistant-backend/pull/20#issue-3138476056