### PR TITLE
FEAT: FAQ 질문 편집 기능 구현

### DIFF
--- a/weather-assistant/src/screens/Home/Home.css
+++ b/weather-assistant/src/screens/Home/Home.css
@@ -347,6 +347,19 @@
   outline: none;
 }
 
+/* FAQ 버튼 내부 텍스트 래퍼 */
+.FAQ-button-text {
+  /* 텍스트 오버플로우 처리 - 2줄까지 표시하고 나머지는 ... */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  text-align: left;
+  line-height: 22px;
+}
+
 /* FAQ 버튼 호버 효과 */
 .FAQ-button:hover {
   background: rgba(255, 255, 255, 0.12);
@@ -426,14 +439,137 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
 }
-
-
 
 /* 편집 버튼 호버 시 아이콘 효과 */
 .FAQ-edit-btn:hover .edit-icon {
   opacity: 1;
+}
+
+/* FAQ 편집 모드 스타일 */
+.FAQ-edit-mode {
+  /* 크기 - 카드 전체 크기 */
+  width: 100%;
+  height: 100%;
+  
+  /* 레이아웃 */
+  display: flex;
+  flex-direction: column;
+  
+  /* 모양 */
+  border-radius: 16px;
+  border: 0.5px solid rgba(255, 255, 255, 0.3);
+  
+  /* 배경 */
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+  
+  /* 그림자 */
+  box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.15);
+  
+  padding: 8px;
+  position: relative;
+}
+
+/* FAQ 편집 입력창 */
+.FAQ-edit-input {
+  flex: 1;
+  width: 100%;
+  
+  /* 모양 */
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  
+  /* 텍스트 - 기본 FAQ와 동일하게 */
+  font-family: 'Poppins', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  color: #FFFFFF;
+  line-height: 22px;
+  text-align: left;
+  
+  /* 레이아웃 */
+  padding: 4px 8px;
+  resize: none;
+  outline: none;
+  
+  /* 텍스트 오버플로우 처리 - FAQ 버튼과 동일 */
+  overflow: hidden;
+  word-wrap: break-word;
+  word-break: break-word;
+  
+  /* 스크롤바 숨기기 */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.FAQ-edit-input::-webkit-scrollbar {
+  display: none;
+}
+
+/* placeholder 스타일 */
+.FAQ-edit-input::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* FAQ 편집 버튼 컨테이너 */
+.FAQ-edit-buttons {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+/* FAQ 저장/취소 버튼 공통 스타일 */
+.FAQ-save-btn,
+.FAQ-cancel-btn {
+  flex: 1;
+  height: 20px;
+  
+  /* 모양 */
+  border: none;
+  border-radius: 6px;
+  
+  /* 텍스트 */
+  font-family: 'Poppins', sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  
+  /* 인터랙션 */
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+/* FAQ 저장 버튼 */
+.FAQ-save-btn {
+  background: linear-gradient(45deg, #97F5FD 15.63%, #EEB4F3 85.42%);
+  color: #091837;
+}
+
+.FAQ-save-btn:hover {
+  background: linear-gradient(45deg, #87E5ED 15.63%, #DEA4E3 85.42%);
+  transform: translateY(-1px);
+}
+
+.FAQ-save-btn:active {
+  transform: translateY(0);
+}
+
+/* FAQ 취소 버튼 */
+.FAQ-cancel-btn {
+  background: rgba(255, 255, 255, 0.1);
+  color: #FFFFFF;
+  border: 0.5px solid rgba(255, 255, 255, 0.2);
+}
+
+.FAQ-cancel-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: translateY(-1px);
+}
+
+.FAQ-cancel-btn:active {
+  transform: translateY(0);
 }
 
 /* 하단 채팅창 컨테이너 */

--- a/weather-assistant/src/screens/Home/Home.js
+++ b/weather-assistant/src/screens/Home/Home.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './Home.css';
 import { WeatherDescriptionWithIcon } from './weatherIconUtils';
 
@@ -15,7 +15,62 @@ const Home = ({
   const today = new Date();
   const formattedDate = formatDate(today); // ex. "May 24, Monday"
 
+  // 기본 FAQ 데이터
+  const defaultFaqItems = [
+    "What's the weather like today?",
+    "How's the air quality today?", 
+    "Do I need an umbrella today?",
+    "What should I wear today?"
+  ];
 
+  // FAQ 편집 상태 관리 - 로컬 스토리지에서 불러오기
+  const [faqItems, setFaqItems] = useState(() => {
+    try {
+      const savedFaqItems = localStorage.getItem('lumeeFaqItems');
+      return savedFaqItems ? JSON.parse(savedFaqItems) : defaultFaqItems;
+    } catch (error) {
+      console.error('FAQ 데이터 로드 실패:', error);
+      return defaultFaqItems;
+    }
+  });
+  
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editText, setEditText] = useState("");
+
+  // FAQ 데이터가 변경될 때마다 로컬 스토리지에 저장
+  useEffect(() => {
+    try {
+      localStorage.setItem('lumeeFaqItems', JSON.stringify(faqItems));
+    } catch (error) {
+      console.error('FAQ 데이터 저장 실패:', error);
+    }
+  }, [faqItems]);
+
+  // FAQ 편집 시작
+  const startEditing = (index) => {
+    setEditingIndex(index);
+    setEditText(faqItems[index]);
+  };
+
+  // FAQ 편집 저장
+  const saveEdit = () => {
+    if (editText.trim() === '') {
+      alert('FAQ 내용을 입력해주세요!');
+      return;
+    }
+    
+    const newFaqItems = [...faqItems];
+    newFaqItems[editingIndex] = editText.trim();
+    setFaqItems(newFaqItems);
+    setEditingIndex(null);
+    setEditText("");
+  };
+
+  // FAQ 편집 취소
+  const cancelEdit = () => {
+    setEditingIndex(null);
+    setEditText("");
+  };
 
   return (
     <div className="app-container"> {/* ✅ 공통 정렬용 래퍼 추가 */}
@@ -108,85 +163,56 @@ const Home = ({
       {/* FAQ 버튼 섹션 */}
       <div className="faq-section">
         <div className="FAQ-buttons">
-          <div className="FAQ-card">
-            <button 
-              className="FAQ-button"
-              onClick={() => sendFromFAQ("What's the weather like today?")}
-            >
-              What's the weather like today?
-            </button>
-            <button 
-              className="FAQ-edit-btn"
-              onClick={() => console.log("Edit FAQ 1")}
-              aria-label="FAQ 수정"
-            >
-              <img 
-                src={`${process.env.PUBLIC_URL}/assets/icons/edit.svg`}
-                alt="수정"
-                className="edit-icon"
-              />
-            </button>
-          </div>
-
-          <div className="FAQ-card">
-            <button 
-              className="FAQ-button"
-              onClick={() => sendFromFAQ("How's the air quality today?")}
-            >
-              How's the air quality today?
-            </button>
-            <button 
-              className="FAQ-edit-btn"
-              onClick={() => console.log("Edit FAQ 2")}
-              aria-label="FAQ 수정"
-            >
-              <img 
-                src={`${process.env.PUBLIC_URL}/assets/icons/edit.svg`}
-                alt="수정"
-                className="edit-icon"
-              />
-            </button>
-          </div>
-
-          <div className="FAQ-card">
-            <button 
-              className="FAQ-button"
-              onClick={() => sendFromFAQ("Do I need an umbrella today?")}
-            >
-              Do I need an umbrella today?
-            </button>
-            <button 
-              className="FAQ-edit-btn"
-              onClick={() => console.log("Edit FAQ 3")}
-              aria-label="FAQ 수정"
-            >
-              <img 
-                src={`${process.env.PUBLIC_URL}/assets/icons/edit.svg`}
-                alt="수정"
-                className="edit-icon"
-              />
-            </button>
-          </div>
-
-          <div className="FAQ-card">
-            <button 
-              className="FAQ-button"
-              onClick={() => sendFromFAQ("What should I wear today?")}
-            >
-              What should I wear today?
-            </button>
-            <button 
-              className="FAQ-edit-btn"
-              onClick={() => console.log("Edit FAQ 4")}
-              aria-label="FAQ 수정"
-            >
-              <img 
-                src={`${process.env.PUBLIC_URL}/assets/icons/edit.svg`}
-                alt="수정"
-                className="edit-icon"
-              />
-            </button>
-          </div>
+          {faqItems.map((faqText, index) => (
+            <div key={index} className="FAQ-card">
+              {editingIndex === index ? (
+                // 편집 모드
+                <div className="FAQ-edit-mode">
+                  <textarea
+                    className="FAQ-edit-input"
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    autoFocus
+                  />
+                  <div className="FAQ-edit-buttons">
+                    <button 
+                      className="FAQ-save-btn"
+                      onClick={saveEdit}
+                    >
+                      Save
+                    </button>
+                    <button 
+                      className="FAQ-cancel-btn"
+                      onClick={cancelEdit}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                // 일반 모드
+                <>
+                  <button 
+                    className="FAQ-button"
+                    onClick={() => sendFromFAQ(faqText)}
+                  >
+                    <span className="FAQ-button-text">{faqText}</span>
+                  </button>
+                  <button 
+                    className="FAQ-edit-btn"
+                    onClick={() => startEditing(index)}
+                    aria-label="FAQ 수정"
+                  >
+                    <img 
+                      src={`${process.env.PUBLIC_URL}/assets/icons/edit.svg`}
+                      alt="수정"
+                      className="edit-icon"
+                    />
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
         </div>
       </div>
 


### PR DESCRIPTION
# 요약
홈 화면의 FAQ 카드(자주 묻는 질문)를 사용자가 직접 수정할 수 있도록 편집 기능을 추가하였습니다.

# 작업 내용
- FAQ 우측 상단에 있는 연필 아이콘(편집 버튼)을 클릭하면, 해당 질문이 textarea 입력창으로 바뀌고 편집 모드로 전환됩니다.
- 텍스트를 수정한 후 Save 버튼을 누르면 FAQ 내용이 변경되고, localStorage에 저장되어 새로고침 후에도 유지됩니다.
- Cancel 버튼을 누르면 수정 없이 원래 질문으로 돌아갑니다.
- 긴 질문은 2줄까지만 표시되고 말줄임(...) 처리됩니다.
- 전체적으로 기존 FAQ 카드와 어울리는 동일한 UI 스타일을 유지하며, 저장/취소 버튼 디자인도 통일감 있게 적용했습니다.

![image](https://github.com/user-attachments/assets/b42b8dfe-fb74-4c98-bf97-c8f8ff53019e)
![image](https://github.com/user-attachments/assets/ce734ce1-c559-47e2-b78a-b319f1a5cb27)

# 참고사항
되돌리고 싶을 때는 Chrome 개발자도구에서 Console에 `localStorage.removeItem('lumeeFaqItems')`를 타이핑하고 새로고침하면 FAQ 카드가 초기화됩니다. 
![image](https://github.com/user-attachments/assets/034d2f05-9e0c-448c-a1b4-076b2c70cde2)
![image](https://github.com/user-attachments/assets/377521c2-f3d6-449f-a62c-be48e3dc4218)

