### PR TITLE
FEAT: 백엔드 LLM 기반 로직으로 전면 재구축 

### DIFF
--- a/weather-assistant/src/App.js
+++ b/weather-assistant/src/App.js
@@ -12,6 +12,7 @@ function App() {
   const [location, setLocation] = useState('Fetching location...');
   const [coords, setCoords] = useState(null);
   const [weather, setWeather] = useState(null);
+  const [uid, setUid] = useState('user01');
   
   // 진행 중인 요청을 추적하기 위한 ref
   const abortControllerRef = useRef(null);
@@ -90,214 +91,284 @@ function App() {
     console.log('✅ 모든 상태 초기화 완료');
   };
 
-  // Gemini 호출 + 그래프 통합 - AbortController로 요청 취소 가능하게 수정
-  const callGeminiAPI = async (messageText) => {
-    try {
-      // 이전 요청이 있다면 취소
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
+  // // Gemini 호출 + 그래프 통합 - AbortController로 요청 취소 가능하게 수정
+  // const callGeminiAPI = async (messageText) => {
+  //   try {
+  //     // 이전 요청이 있다면 취소
+  //     if (abortControllerRef.current) {
+  //       abortControllerRef.current.abort();
+  //     }
       
-      // 새로운 AbortController 생성
-      abortControllerRef.current = new AbortController();
-      const signal = abortControllerRef.current.signal;
+  //     // 새로운 AbortController 생성
+  //     abortControllerRef.current = new AbortController();
+  //     const signal = abortControllerRef.current.signal;
       
-      let thinkingShown = false;
-      let thinkingStartTime = null;
+  //     let thinkingShown = false;
+  //     let thinkingStartTime = null;
       
-      // 800ms 후에 "Thinking" 메시지 표시
-      thinkingTimerRef.current = setTimeout(() => {
-        // 요청이 취소되지 않았을 때만 Thinking 표시
-        if (!signal.aborted) {
-          setMessages(prev => [...prev, { type: 'bot', text: 'Thinking', isThinking: true }]);
-          thinkingShown = true;
-          thinkingStartTime = Date.now();
-        }
-      }, 800);
+  //     // 800ms 후에 "Thinking" 메시지 표시
+  //     thinkingTimerRef.current = setTimeout(() => {
+  //       // 요청이 취소되지 않았을 때만 Thinking 표시
+  //       if (!signal.aborted) {
+  //         setMessages(prev => [...prev, { type: 'bot', text: 'Thinking', isThinking: true }]);
+  //         thinkingShown = true;
+  //         thinkingStartTime = Date.now();
+  //       }
+  //     }, 800);
 
-      const res = await fetch('http://localhost:4000/gemini', {
+  //     const res = await fetch('http://localhost:4000/gemini', {
+  //       method: 'POST',
+  //       headers: { 'Content-Type': 'application/json' },
+  //       body: JSON.stringify({ userInput: messageText, location, coords }),
+  //       signal // AbortController 신호 추가
+  //     });
+
+  //     // 요청이 취소되었다면 여기서 중단
+  //     if (signal.aborted) {
+  //       console.log('🚫 요청이 취소되었습니다.');
+  //       return;
+  //     }
+
+  //     // API 응답이 빨리 와서 "Thinking"이 표시되기 전이면 타이머 취소
+  //     if (thinkingTimerRef.current) {
+  //       clearTimeout(thinkingTimerRef.current);
+  //       thinkingTimerRef.current = null;
+  //     }
+
+  //     const data = await res.json();
+  //     const graphCoords = data.resolvedCoords || coords;
+  //     console.log('📍 resolvedCoords:', graphCoords);
+
+  //     // 미세먼지 정보가 포함되어 있으면 추가 메시지 구성
+  //     if (data.airQuality && data.airQuality.pm25 !== undefined) {
+  //       const { pm25 } = data.airQuality;
+
+  //       const getAirLevel = (value) => {
+  //         if (value <= 15) return '좋음';
+  //         if (value <= 35) return '보통';
+  //         if (value <= 75) return '나쁨';
+  //         return '매우 나쁨';
+  //       };
+
+  //       const getAirColor = (value) => {
+  //         if (value <= 15) return '#22c55e';   // green
+  //         if (value <= 35) return '#facc15';   // yellow
+  //         if (value <= 75) return '#f97316';   // orange
+  //         return '#ef4444';                    // red
+  //       };
+
+  //       const dustInfo = {
+  //         value: pm25,
+  //         level: getAirLevel(pm25),
+  //         color: getAirColor(pm25)
+  //       };
+
+  //       // '생각 중...' 메시지 제거 후 응답 메시지 + dust 정보 반영
+  //       setMessages(prev => {
+  //         const newMessages = [...prev];
+  //         newMessages.pop(); // 로딩 제거
+  //         return [...newMessages, {
+  //           type: 'bot',
+  //           text: data.reply,
+  //           dust: dustInfo
+  //         }];
+  //       });
+
+  //       return; // 미세먼지 응답이면 여기서 종료
+  //     }
+
+  //     // 기온 질문 시 그래프 요청
+  //     let graphData = null;
+  //     if (
+  //       (messageText.includes('기온') || messageText.includes('온도')) &&
+  //       graphCoords && graphCoords.lat && graphCoords.lon &&
+  //       !signal.aborted // 취소되지 않았을 때만
+  //     ) {
+  //       const graphRes = await fetch('http://localhost:4000/weather-graph', {
+  //         method: 'POST',
+  //         headers: { 'Content-Type': 'application/json' },
+  //         body: JSON.stringify({
+  //           latitude: graphCoords.lat,
+  //           longitude: graphCoords.lon
+  //         }),
+  //         signal // 그래프 요청에도 취소 신호 추가
+  //       });
+        
+  //       if (!signal.aborted) {
+  //         graphData = await graphRes.json();
+  //       }
+  //     }
+
+  //     // 최종 응답 처리
+  //     const processResponse = () => {
+  //       // 요청이 취소되었다면 상태 업데이트 하지 않음
+  //       if (signal.aborted) {
+  //         console.log('🚫 응답 처리 중단됨 (요청 취소)');
+  //         return;
+  //       }
+        
+  //       setMessages(prev => {
+  //         const newMessages = [...prev];
+          
+  //         // "Thinking"이 표시되었으면 제거
+  //         if (thinkingShown && newMessages[newMessages.length - 1]?.isThinking) {
+  //           newMessages.pop();
+  //         }
+
+  //         return [
+  //           ...newMessages,
+  //           {
+  //             type: 'bot',
+  //             text: data.reply || '응답을 이해하지 못했어요.',
+  //             graph: Array.isArray(graphData?.hourlyTemps) ? graphData.hourlyTemps : null
+  //           }
+  //         ];
+  //       });
+  //     };
+
+  //     if (thinkingShown && thinkingStartTime && !signal.aborted) {
+  //       const elapsed = Date.now() - thinkingStartTime;
+  //       const minDisplayTime = 1000;
+  //       const remainingTime = Math.max(0, minDisplayTime - elapsed);
+        
+  //       setTimeout(() => {
+  //         if (!signal.aborted) {
+  //           processResponse();
+  //         }
+  //       }, remainingTime);
+  //     } else if (!signal.aborted) {
+  //       processResponse();
+  //     }
+
+  //     if (data.error && !signal.aborted) {
+  //       console.error('API 오류:', data.error);
+        
+  //       const processError = () => {
+  //         if (signal.aborted) return;
+          
+  //         setMessages(prev => {
+  //           const newMessages = [...prev];
+            
+  //           if (thinkingShown && newMessages[newMessages.length - 1]?.isThinking) {
+  //             newMessages.pop();
+  //           }
+            
+  //           return [...newMessages, {
+  //             type: 'bot',
+  //             text: `❌ 오류: ${data.error}`
+  //           }];
+  //         });
+  //       };
+
+  //       if (thinkingShown && thinkingStartTime) {
+  //         const elapsed = Date.now() - thinkingStartTime;
+  //         const minDisplayTime = 1000;
+  //         const remainingTime = Math.max(0, minDisplayTime - elapsed);
+  //         setTimeout(processError, remainingTime);
+  //       } else {
+  //         processError();
+  //       }
+  //     }
+
+  //     // 요청 완료 후 AbortController 정리
+  //     abortControllerRef.current = null;
+      
+  //   } catch (error) {
+  //     // AbortError는 정상적인 취소이므로 에러 메시지 표시하지 않음
+  //     if (error.name === 'AbortError') {
+  //       console.log('🚫 요청이 사용자에 의해 취소되었습니다.');
+  //       return;
+  //     }
+      
+  //     const processErrorCatch = () => {
+  //       setMessages(prev => {
+  //         const newMessages = [...prev];
+          
+  //         if (newMessages[newMessages.length - 1]?.isThinking) {
+  //           newMessages.pop();
+  //         }
+          
+  //         return [...newMessages, {
+  //           type: 'bot',
+  //           text: `❌ ${error.message}`
+  //         }];
+  //       });
+  //     };
+
+  //     processErrorCatch();
+      
+  //     // 에러 발생 시에도 AbortController 정리
+  //     abortControllerRef.current = null;
+  //   }
+  // };
+
+// ✨ API 호출 함수 (새로운 백엔드 아키텍처에 맞게 대폭 수정됨) ✨
+  // ==================================================================
+  const callGeminiAPI = async (messageText) => {
+    // 이전 요청이 있다면 취소
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    abortControllerRef.current = new AbortController();
+    const signal = abortControllerRef.current.signal;
+    
+    // "Thinking..." 메시지 표시 로직
+    let thinkingShown = false;
+    thinkingTimerRef.current = setTimeout(() => {
+      if (signal.aborted) return;
+      setMessages(prev => [...prev, { type: 'bot', text: 'Thinking', isThinking: true }]);
+      thinkingShown = true;
+    }, 800);
+
+    try {
+      // ✅ 엔드포인트를 /chat으로 변경하고, uid를 함께 전송합니다.
+      const res = await fetch('http://localhost:4000/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userInput: messageText, location, coords, uid: 'testUser1' }),
         signal // AbortController 신호 추가
       });
 
-      // 요청이 취소되었다면 여기서 중단
-      if (signal.aborted) {
-        console.log('🚫 요청이 취소되었습니다.');
-        return;
-      }
+      // API 응답이 빨리 오면 Thinking 타이머 취소
+      clearTimeout(thinkingTimerRef.current);
 
-      // API 응답이 빨리 와서 "Thinking"이 표시되기 전이면 타이머 취소
-      if (thinkingTimerRef.current) {
-        clearTimeout(thinkingTimerRef.current);
-        thinkingTimerRef.current = null;
-      }
+      if (signal.aborted) return;
 
       const data = await res.json();
-      const graphCoords = data.resolvedCoords || coords;
-      console.log('📍 resolvedCoords:', graphCoords);
 
-      // 미세먼지 정보가 포함되어 있으면 추가 메시지 구성
-      if (data.airQuality && data.airQuality.pm25 !== undefined) {
-        const { pm25 } = data.airQuality;
-
-        const getAirLevel = (value) => {
-          if (value <= 15) return '좋음';
-          if (value <= 35) return '보통';
-          if (value <= 75) return '나쁨';
-          return '매우 나쁨';
-        };
-
-        const getAirColor = (value) => {
-          if (value <= 15) return '#22c55e';   // green
-          if (value <= 35) return '#facc15';   // yellow
-          if (value <= 75) return '#f97316';   // orange
-          return '#ef4444';                    // red
-        };
-
-        const dustInfo = {
-          value: pm25,
-          level: getAirLevel(pm25),
-          color: getAirColor(pm25)
-        };
-
-        // '생각 중...' 메시지 제거 후 응답 메시지 + dust 정보 반영
-        setMessages(prev => {
+      // "Thinking" 메시지를 실제 응답으로 교체
+      setMessages(prev => {
           const newMessages = [...prev];
-          newMessages.pop(); // 로딩 제거
-          return [...newMessages, {
-            type: 'bot',
-            text: data.reply,
-            dust: dustInfo
-          }];
-        });
-
-        return; // 미세먼지 응답이면 여기서 종료
-      }
-
-      // 기온 질문 시 그래프 요청
-      let graphData = null;
-      if (
-        (messageText.includes('기온') || messageText.includes('온도')) &&
-        graphCoords && graphCoords.lat && graphCoords.lon &&
-        !signal.aborted // 취소되지 않았을 때만
-      ) {
-        const graphRes = await fetch('http://localhost:4000/weather-graph', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            latitude: graphCoords.lat,
-            longitude: graphCoords.lon
-          }),
-          signal // 그래프 요청에도 취소 신호 추가
-        });
-        
-        if (!signal.aborted) {
-          graphData = await graphRes.json();
-        }
-      }
-
-      // 최종 응답 처리
-      const processResponse = () => {
-        // 요청이 취소되었다면 상태 업데이트 하지 않음
-        if (signal.aborted) {
-          console.log('🚫 응답 처리 중단됨 (요청 취소)');
-          return;
-        }
-        
-        setMessages(prev => {
-          const newMessages = [...prev];
-          
-          // "Thinking"이 표시되었으면 제거
+          // Thinking 메시지가 있다면 제거
           if (thinkingShown && newMessages[newMessages.length - 1]?.isThinking) {
             newMessages.pop();
           }
-
+          // 백엔드에서 받은 데이터로 새 메시지 추가
           return [
             ...newMessages,
             {
               type: 'bot',
               text: data.reply || '응답을 이해하지 못했어요.',
-              graph: Array.isArray(graphData?.hourlyTemps) ? graphData.hourlyTemps : null
+              // 백엔드가 그래프/미세먼지 데이터를 주면 그대로 할당
+              graph: data.graph || null,
+              dust: data.dust || null
             }
           ];
-        });
-      };
+      });
 
-      if (thinkingShown && thinkingStartTime && !signal.aborted) {
-        const elapsed = Date.now() - thinkingStartTime;
-        const minDisplayTime = 1000;
-        const remainingTime = Math.max(0, minDisplayTime - elapsed);
-        
-        setTimeout(() => {
-          if (!signal.aborted) {
-            processResponse();
-          }
-        }, remainingTime);
-      } else if (!signal.aborted) {
-        processResponse();
-      }
-
-      if (data.error && !signal.aborted) {
-        console.error('API 오류:', data.error);
-        
-        const processError = () => {
-          if (signal.aborted) return;
-          
-          setMessages(prev => {
-            const newMessages = [...prev];
-            
-            if (thinkingShown && newMessages[newMessages.length - 1]?.isThinking) {
-              newMessages.pop();
-            }
-            
-            return [...newMessages, {
-              type: 'bot',
-              text: `❌ 오류: ${data.error}`
-            }];
-          });
-        };
-
-        if (thinkingShown && thinkingStartTime) {
-          const elapsed = Date.now() - thinkingStartTime;
-          const minDisplayTime = 1000;
-          const remainingTime = Math.max(0, minDisplayTime - elapsed);
-          setTimeout(processError, remainingTime);
-        } else {
-          processError();
-        }
-      }
-
-      // 요청 완료 후 AbortController 정리
-      abortControllerRef.current = null;
-      
     } catch (error) {
-      // AbortError는 정상적인 취소이므로 에러 메시지 표시하지 않음
       if (error.name === 'AbortError') {
         console.log('🚫 요청이 사용자에 의해 취소되었습니다.');
         return;
       }
-      
-      const processErrorCatch = () => {
-        setMessages(prev => {
-          const newMessages = [...prev];
-          
-          if (newMessages[newMessages.length - 1]?.isThinking) {
-            newMessages.pop();
-          }
-          
-          return [...newMessages, {
-            type: 'bot',
-            text: `❌ ${error.message}`
-          }];
-        });
-      };
-
-      processErrorCatch();
-      
-      // 에러 발생 시에도 AbortController 정리
-      abortControllerRef.current = null;
+      // 그 외 네트워크 오류 등 처리
+      clearTimeout(thinkingTimerRef.current);
+      setMessages(prev => {
+          const newMessages = [...prev].filter(m => !m.isThinking);
+          return [...newMessages, { type: 'bot', text: `❌ 오류가 발생했어요: ${error.message}` }];
+      });
+    } finally {
+        abortControllerRef.current = null;
     }
   };
 

--- a/weather-assistant/src/screens/Chat/WeatherLineChart.js
+++ b/weather-assistant/src/screens/Chat/WeatherLineChart.js
@@ -32,14 +32,26 @@ const WeatherLineChart = ({ graph }) => {
     ]
   };
 
-  const options = {
-    responsive: true,
-    plugins: {
-      tooltip: {
-        enabled: true
+const options = {
+  responsive: true,
+  plugins: {
+    tooltip: {
+      enabled: true
+    }
+  },
+  scales: {
+    y: {
+      ticks: {
+        callback: function(value) {
+          return `${value}°C`;
+        },
+        font: {
+          size: 12
+        }
       }
     }
-  };
+  }
+};
 
   return (
     <div style={{ height: 250 }}>


### PR DESCRIPTION
## 요약
API 호출 함수를 새로운 백엔드 아키텍처에 맞게 수정하였습니다. 이전에 사용되던 코드는 전부 주석처리 하였습니다.

온도 그래프에서 출력되는 y축에 `°C` 단위를 붙였습니다.
![image](https://github.com/user-attachments/assets/1c7d7b8a-5451-4366-bc57-93aec10dd702)
25 -> 25°C 