### PR TITLE
FIX: 모바일 기기 레이아웃 깨짐 문제 해결

### DIFF
--- a/weather-assistant/src/App.css
+++ b/weather-assistant/src/App.css
@@ -8,69 +8,83 @@
 body {
   font-family: 'Poppins', 'Noto Sans KR', sans-serif;
   color: #ffffff;
-  background: #000;
+  /* 전체 body 배경을 그라데이션으로 */
+  background: linear-gradient(
+    to bottom,
+    #091837 0%,
+    #091837 50%,
+    #1F366F 100%
+  );
+  background-attachment: fixed; /* body에서만 fixed 사용 */
   overflow-x: hidden;
-  
 }
 
 /* 메인 앱 래퍼 */
 .app {
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: center;
-  background: #000;
+  align-items: flex-start;
+  
+  /* 배경 투명 - body 배경 그대로 보이게 */
+  background: transparent;
 }
 
 /* 핵심 앱 컨테이너 */
 .app-container {
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
   max-width: 430px;
-  max-height: 932px;
   
   /* 안전 영역 처리 */
-  /* iPhone 14 Pro Max 기준 설정 */
   padding-top: env(safe-area-inset-top, 59px); 
   padding-bottom: env(safe-area-inset-bottom, 34px);
   padding-left: env(safe-area-inset-left, 20px);
   padding-right: env(safe-area-inset-right, 20px);
-  
 
-  /* 배경 */
-  background: linear-gradient(
-    180deg,
-    #091837 0%,
-    #091837 50%,
-    #1F366F 100%
-  );
+  /* 배경 투명 - body 배경 그대로 보이게 */
+  background: transparent;
   
   /* 레이아웃 */
   display: flex;
   flex-direction: column;
   position: relative;
   margin: 0 auto;
-  /* overflow: hidden; */
 }
-
-
 
 /* 데스크톱에서 카드 스타일 */
 @media (min-width: 768px) {
-  .app {
+  body {
+    /* 데스크톱에서는 일반 배경 */
     background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    background-attachment: scroll;
+  }
+  
+  .app {
+    background: transparent;
     padding: 40px;
+    align-items: center;
   }
   
   /* 휴대폰 모양 만들기 */
   .app-container {
     width: 430px;
     height: 932px;
+    min-height: 932px;
     border-radius: 40px;
     border: 8px solid #48484a;
+    overflow: hidden;
+    
+    /* 데스크톱에서만 앱 컨테이너에 그라데이션 적용 */
+    background: linear-gradient(
+      180deg,
+      #091837 0%,
+      #091837 50%,
+      #1F366F 100%
+    );
   
-  /* 프리미엄 메탈릭 효과 */
+    /* 프리미엄 메탈릭 효과 */
     box-shadow: 
       0 25px 80px rgba(0, 0, 0, 0.7),
       inset 0 1px 0 rgba(255, 255, 255, 0.25),

--- a/weather-assistant/src/screens/Chat/Chat.css
+++ b/weather-assistant/src/screens/Chat/Chat.css
@@ -246,20 +246,20 @@
 
 /* 하단 채팅창 컨테이너 */
 .footer-input {
-  position: absolute;
-  top: 830px;
-  left: 50%;
-  transform: translateX(-50%);
+   position: absolute;
+  top: 809px;
   
-  width: 390px;
-  max-width: 390px;
+  /* 헤더처럼 padding으로 마진 처리 */
+  left: 0;
+  right: 0;
+  padding: 24px min(20px, 5vw) 51px min(20px, 5vw) !important;
   
   display: flex;
   gap: 8px; 
   align-items: center;
+  justify-content: center;
   
-  padding: 0;
-  margin: 0;
+  margin: 0 !important;
   z-index: 20;
 }
 

--- a/weather-assistant/src/screens/Home/Home.css
+++ b/weather-assistant/src/screens/Home/Home.css
@@ -315,17 +315,16 @@
   width: 100%;
   height: 56px;
   position: absolute;
-  top: 59px; /* 상태바 밑에 */
+  top: calc(59px + env(safe-area-inset-top, 0px)); /* 안전영역 추가 */
   
   background: transparent;
   
-  display: flex;    /* 자식들을 가로로 나란히 배치 */
-  justify-content: space-between;  /* 첫째는 왼쪽, 셋째는 오른쪽, 둘째는 가운데 */
-  align-items: center;   /* 모든 자식을 세로 중앙 정렬 */
-  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 min(20px, 5vw); /* 반응형 패딩 */
   z-index: 10;
 }
-
 
 /* 왼쪽 메뉴 버튼 */
 .header-menu-btn {
@@ -382,19 +381,19 @@
   transform: scale(0.95);          /* 클릭시 크기 5% 축소 */
 }
 
+/* 헤더 위치 버튼 - 텍스트 오버플로우 개선 */
 .header-location-name {
-  /* 필수 텍스트 스타일 */
   font-family: 'Poppins', sans-serif;
-  font-size: 22px;
+  font-size: clamp(18px, 5.1vw, 22px);
   font-weight: 400;
   color: #FFFFFF;
   
-  /* 오버플로우 처리 - 지역 이름이 길 때 */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 270px;        /*  최대 너비 */
+  max-width: calc(100vw - min(160px, 40vw)); /* 메뉴 버튼과 프로필 공간 제외 */
 }
+
 
 /* 프로필 버튼 - 32x32 고정 크기 */
 .header-profile {
@@ -565,46 +564,46 @@
   margin: 0;
 }
 
+/* 메인 질문 - 마진 적용 */
 .main-question {
-  width: 386px;
-  height: 30px;                  
+  width: calc(100% - min(40px, 10vw)); /* 헤더와 동일한 마진 */
+  max-width: 386px;
+  height: 30px;
   
   position: absolute;
-  top: 582px;
+  top: calc(582px + env(safe-area-inset-top, 0px));
   left: 50%;
   transform: translateX(-50%);
   
   font-family: 'Poppins', sans-serif;
-  font-size: 20px;
+  font-size: clamp(18px, 4.7vw, 20px);
   font-weight: 600;
   text-align: center;
   line-height: 30px;
   
   /* 그라데이션 텍스트 */
   background: linear-gradient(90deg, #97F5FD 0%, #EEB4F3 100%);
-
-  /* 브라우저 호환성 */
-  color: #FFFFFF;                        /* 1. 대체용: 오래된 브라우저용 기본 색상 */
-  -webkit-background-clip: text;         /* 2. 웹킷: Safari, Chrome용 */
-  -webkit-text-fill-color: transparent; /* 2. 웹킷: 텍스트 색상 투명하게 */
-  background-clip: text;                 /* 3. 표준: 최신 브라우저용 */
-  color: transparent;                    /* 3. 표준: 텍스트 색상 투명하게 */
-  
+  color: #FFFFFF;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
   
   margin: 0;
 }
 
-/* FAQ 카드 컨테이너 (그리드) */
+/* FAQ 카드 컨테이너 - 헤더와 동일한 마진 적용 */
 .FAQ-buttons {
   display: grid;
-  grid-template-columns: 1fr 1fr; /* 2열 */
-  gap: 16px;                       /* 카드 사이 간격 */
+  grid-template-columns: 1fr 1fr;
+  gap: min(16px, 4vw);
   
   position: absolute;
-  top: 635px;                      /* 적절한 위치 */
+  top: calc(635px + env(safe-area-inset-top, 0px));
   left: 50%;
   transform: translateX(-50%);
-  width: 390px;                    /* 전체 컨테이너 너비 */
+  width: calc(100% - min(40px, 10vw)); /* 헤더 패딩 * 2 만큼 빼기 */
+  max-width: 390px; /* 최대 너비 제한 */
   
   padding: 0;
   margin: 0;
@@ -614,7 +613,7 @@
 /* 개별 FAQ 카드 래퍼 - 꼭 필요 */
 .FAQ-card {
   position: relative;              /* 편집 버튼 절대 위치 기준점 */
-  width: 187px;
+  width: 100%;
   height: 79px;
 }
 
@@ -888,19 +887,19 @@
 /* 하단 채팅창 컨테이너 */
 .footer-input {
   position: absolute;
-  top: 830px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 809px;
   
-  width: 390px;
-  max-width: 390px;
+  /* 헤더처럼 padding으로 마진 처리 */
+  left: 0;
+  right: 0;
+  padding: 24px min(20px, 5vw) 51px min(20px, 5vw) !important;
   
   display: flex;
   gap: 8px; 
   align-items: center;
+  justify-content: center;
   
-  padding: 0;
-  margin: 0;
+  margin: 0 !important;
   z-index: 20;
 }
 

--- a/weather-assistant/src/screens/Home/Home.js
+++ b/weather-assistant/src/screens/Home/Home.js
@@ -262,6 +262,7 @@ const Home = ({
           muted
           playsInline
           key={selectedOrb} // 키를 변경하여 비디오 리로드 강제
+          controls={false}  
         >
           <source
             src={currentOrb.videoSrc.mp4}

--- a/weather-assistant/src/screens/Home/Home.js
+++ b/weather-assistant/src/screens/Home/Home.js
@@ -66,7 +66,7 @@ const Home = ({
       name: 'Rain',
       description: 'Rain-reactive magic orb',
       videoSrc: {
-        mp4: "https://res.cloudinary.com/dpuw0gcaf/video/upload/v1749988390/finedustLumee_Safari_tkyral.mov",
+        mp4: "https://res.cloudinary.com/dpuw0gcaf/video/upload/v1749984449/rainLumee_Safari_iyfm0v.mov",
         webm: "https://res.cloudinary.com/dpuw0gcaf/video/upload/v1749984445/rainLumee_WEBM_xblf7o.webm"
       }
     }
@@ -199,7 +199,7 @@ const Home = ({
             
             {/* 메뉴 푸터 */}
             <div className="menu-footer">
-              <p className="beta-notice">This is a BETA feature. Auto-adaptive orbs & more styles coming soon!</p>
+              <p className="beta-notice">This is a BETA feature. Auto-reactive orbs & more styles coming soon!</p>
             </div>
           </div>
         </div>

--- a/weather-assistant/src/screens/VoiceInput/VoiceInput.css
+++ b/weather-assistant/src/screens/VoiceInput/VoiceInput.css
@@ -1,7 +1,7 @@
 /* ========== VoiceInput 전용 배경 비디오 스타일 ========== */
 .voice-magic-orb {
-  width: 320px;                
-  height: 320px;               
+  width: min(320px, 80vw);                
+  height: min(320px, 80vw);               
   position: absolute;
   top: 210px;                  
   left: 50%;                   
@@ -25,16 +25,16 @@
 /* ========== 헤더 스타일 ========== */
 .weather-header {
   width: 100%;
-  height: 56px;
+  height: clamp(48px, 8vh, 56px);
   position: absolute;
-  top: 59px;
+  top: clamp(40px, 8vh, 59px);
   
   background: transparent;
   
   display: flex;   
   justify-content: space-between; 
   align-items: center;  
-  padding: 0 20px;
+  padding: 0 clamp(16px, 4vw, 20px);
   z-index: 10;
 }
 
@@ -58,8 +58,8 @@
 }
 
 .back-icon {
-  width: 24px;
-  height: 24px;
+  width: clamp(20px, 5vw, 24px);
+  height: clamp(20px, 5vw, 24px);
   filter: brightness(0) invert(1);
 }
 
@@ -68,8 +68,8 @@
 }
 
 .header-icon-placeholder {
-  width: 24px;  
-  height: 24px; 
+  width: clamp(20px, 5vw, 24px);  
+  height: clamp(20px, 5vw, 24px); 
   visibility: hidden;
 }
 
@@ -164,7 +164,7 @@
   align-items: center;
   justify-content: flex-end;
   z-index: 5;
-  padding: 20px;
+  padding: clamp(16px, 4vw, 20px);
   pointer-events: none;
 }
 
@@ -178,8 +178,8 @@
   color: #ffffff;
   text-align: center;
   z-index: 10;
-  width: calc(100vw - 160px);  /* 양쪽 80px씩 = 160px */
-  max-width: 270px;            /* 원형 영상과 동일한 270px */
+  width: calc(100vw - 40px);
+  max-width: 320px;
   font-weight: 400;
   letter-spacing: 0.5px;
   line-height: 1.4;
@@ -280,3 +280,146 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ========== 아이폰 SE 및 작은 화면 대응 (최우선) ========== */
+@media (max-width: 414px) {
+  .voice-magic-orb {
+    width: 280px !important;
+    height: 280px !important;
+  }
+  
+  .voice-partial-text {
+    bottom: 120px !important;
+    font-size: 24px !important;
+    width: calc(100vw - 40px) !important;
+    max-width: 300px !important;
+  }
+}
+
+/* ========== 아이폰 SE 전용 (375x667) ========== */
+@media (max-width: 375px) and (max-height: 667px) {
+  .voice-magic-orb {
+    width: 260px !important;
+    height: 260px !important;
+  }
+  
+  .listening-text,
+  .error-text {
+    font-size: 18px !important;
+  }
+  
+  .voice-partial-text {
+    bottom: 50px !important;
+    font-size: 22px !important;
+    width: calc(100vw - 30px) !important;
+    max-width: 280px !important;
+    line-height: 1.3 !important;
+  }
+}
+
+/* ========== 아이폰 SE보다 작은 화면 대응 ========== */
+@media (max-width: 320px) {
+  .voice-magic-orb {
+    width: 240px !important;
+    height: 240px !important;
+  }
+  
+  .listening-text,
+  .error-text {
+    font-size: 16px !important;
+  }
+  
+  .voice-partial-text {
+    bottom: 80px !important;
+    font-size: 20px !important;
+  }
+}
+
+@media (max-height: 600px) {
+  .voice-magic-orb {
+    top: clamp(120px, 20vh, 160px);
+    width: min(280px, 70vw);
+    height: min(280px, 70vw);
+  }
+  
+  .listening-text,
+  .error-text {
+    top: clamp(100px, 18vh, 130px);
+  }
+  
+  .voice-partial-text {
+    bottom: clamp(140px, 25vh, 180px);
+    font-size: clamp(20px, 5vw, 28px);
+  }
+}
+
+@media (max-height: 500px) {
+  .voice-magic-orb {
+    top: clamp(80px, 15vh, 120px);
+    width: min(240px, 60vw);
+    height: min(240px, 60vw);
+  }
+  
+  .listening-text,
+  .error-text {
+    top: clamp(60px, 12vh, 90px);
+    font-size: clamp(16px, 4vw, 20px);
+  }
+  
+  .voice-partial-text {
+    bottom: clamp(100px, 20vh, 140px);
+    font-size: clamp(18px, 4.5vw, 24px);
+  }
+  
+  .weather-header {
+    top: clamp(20px, 4vh, 40px);
+    height: clamp(40px, 6vh, 48px);
+  }
+}
+
+/* ========== 가로 모드 대응 ========== */
+@media (orientation: landscape) and (max-height: 500px) {
+  .voice-magic-orb {
+    top: clamp(60px, 12vh, 100px);
+    width: min(200px, 50vw);
+    height: min(200px, 50vw);
+  }
+  
+  .listening-text,
+  .error-text {
+    top: clamp(40px, 8vh, 70px);
+    font-size: clamp(14px, 3.5vw, 18px);
+  }
+  
+  .voice-partial-text {
+    bottom: clamp(80px, 16vh, 120px);
+    font-size: clamp(16px, 4vw, 22px);
+    width: clamp(200px, 70vw, 280px);
+  }
+}
+
+/* ========== 큰 화면 대응 ========== */
+@media (min-width: 768px) {
+  .voice-magic-orb {
+    width: 320px;
+    height: 320px;
+    top: 210px;
+  }
+  
+  .listening-text,
+  .error-text {
+    top: 180px;
+    font-size: 22px;
+  }
+  
+  .voice-partial-text {
+    bottom: 254px;
+    font-size: 32px;
+    max-width: 320px;
+  }
+  
+  .weather-header {
+    top: 59px;
+    height: 56px;
+    padding: 0 20px;
+  }
+}


### PR DESCRIPTION
# 요약
데스크탑, 아이패드 등 큰 화면 기기에서는 iPhone 14 Pro Max 해상도(430x932) 기준으로 고정된 레이아웃이 적용되며, 모바일에서는 각 기기의 해상도에 맞춰 유동적으로 표시됩니다. 이에 따라 iPhone 14 Pro Max가 아닌 일부 모바일 기기에서 레이아웃 깨짐 현상이 발생하였고, 크롬 개발자 도구를 활용해 다양한 모바일 해상도를 기준으로 테스트 및 조정을 진행하여 해당 문제를 최대한 해결하였습니다.
![image](https://github.com/user-attachments/assets/9edbe2a8-8833-46c5-9bd5-2594b53b1349)


# 작업내용
**1. 일부 모바일 기기에서 그라데이션 배경과 함께 검은 배경이 나오는 문제를 해결하였습니다.**
![image](https://github.com/user-attachments/assets/8910d45d-58aa-4b03-a1f2-87b297cf47ca)

**2. FAQ 카드 및 푸터가 화면 끝에 밀착되는 현상을 해결하였습니다.**
![image](https://github.com/user-attachments/assets/33877d1a-0ff5-4028-8d33-66593be1b22d)

**3. 음성입력 화면에서 마법구슬과 입력텍스트가 겹치는 현상을 해결하였습니다.**
![image](https://github.com/user-attachments/assets/e980f769-142c-46e7-85a5-f930da07892f)

# 참고사항
보다 안정적인 UI와 시각적 완성도를 위해 데스크탑 환경에서의 사용을 권장합니다..